### PR TITLE
[2.3] increase the default appliedmanifestwork eviction grace period …

### DIFF
--- a/pkg/spoke/spokeagent.go
+++ b/pkg/spoke/spokeagent.go
@@ -56,7 +56,7 @@ func NewWorkloadAgentOptions() *WorkloadAgentOptions {
 		QPS:                                    50,
 		Burst:                                  100,
 		StatusSyncInterval:                     10 * time.Second,
-		AppliedManifestWorkEvictionGracePeriod: 10 * time.Minute,
+		AppliedManifestWorkEvictionGracePeriod: 60 * time.Minute,
 	}
 }
 


### PR DESCRIPTION
…to 60 minutes
The related issue: https://issues.redhat.com/browse/ACM-6178